### PR TITLE
use git to download drupal 8

### DIFF
--- a/scripts/install_drupal8.sh
+++ b/scripts/install_drupal8.sh
@@ -4,4 +4,4 @@ PROJECTNAME=$(basename $MAINPATH)
 
 docker exec -i --user=1000:1000 $PROJECTNAME-apache composer global require drush/drush:dev-master
 docker exec $PROJECTNAME-apache ln -s /home/www-bridge-user/.composer/vendor/bin/drush /usr/bin/drush
-docker exec -i --user=1000:1000 $PROJECTNAME-apache sh -c 'drush dl -y --destination=/var/www/html --drupal-project-rename=drupal8 drupal-8.0.x-dev && cd /var/www/html/drupal8 && drush si --db-url=mysql://root:123@db/drupal8 -y'
+docker exec -i --user=1000:1000 $PROJECTNAME-apache sh -c 'git clone --branch 8.2.x https://git.drupal.org/project/drupal.git /var/www/html/drupal8 && cd /var/www/html/drupal8 && composer install && drush si --db-url=mysql://root:123@db/drupal8 --account-pass=admin -y'


### PR DESCRIPTION
Use git to clone drupal 8 repository, use 8.2.x version and set default password to site installation
